### PR TITLE
fix(popover): correct arrow borders for left/right placements

### DIFF
--- a/elements/popover/src/el-dm-popover.ts
+++ b/elements/popover/src/el-dm-popover.ts
@@ -89,13 +89,13 @@ const styles = css`
 
   .popover-content[data-placement^='left'] .popover-arrow {
     right: -0.4375rem;
-    border-top: none;
+    border-bottom: none;
     border-left: none;
   }
 
   .popover-content[data-placement^='right'] .popover-arrow {
     left: -0.4375rem;
-    border-bottom: none;
+    border-top: none;
     border-right: none;
   }
 


### PR DESCRIPTION
## Summary
- Fix incorrect CSS border-hiding rules for left/right popover arrow placements
- Left placement: changed `border-top: none` → `border-bottom: none`
- Right placement: changed `border-bottom: none` → `border-top: none`

Fixes #8