### PR TITLE
feat(badge): add role="status" and aria-label forwarding

### DIFF
--- a/elements/badge/src/el-dm-badge.ts
+++ b/elements/badge/src/el-dm-badge.ts
@@ -140,8 +140,11 @@ export class ElDmBadge extends BaseElement {
   render(): string {
     const badgeClasses = this._getBadgeClasses();
 
+    const ariaLabel = this.getAttribute('aria-label');
+    const ariaLabelAttr = ariaLabel ? ` aria-label="${ariaLabel}"` : '';
+
     return `
-      <span class="${badgeClasses}" part="badge">
+      <span class="${badgeClasses}" part="badge" role="status"${ariaLabelAttr}>
         ${this.dot ? '' : '<slot></slot>'}
       </span>
     `;


### PR DESCRIPTION
## Summary
- Add `role="status"` to the badge span so screen readers announce dynamic content changes
- Forward host `aria-label` to the inner badge span for visual-only badges

Fixes #11