### PR TITLE
fix(accordion): add aria-labelledby on content panel

### DIFF
--- a/elements/accordion/src/el-dm-accordion.ts
+++ b/elements/accordion/src/el-dm-accordion.ts
@@ -237,6 +237,7 @@ export class ElDmAccordionItem extends BaseElement {
           class="accordion-header"
           part="header"
           type="button"
+          id="trigger-${this.value || 'item'}"
           aria-expanded="${this.open ? 'true' : 'false'}"
           aria-controls="content-${this.value || 'item'}"
           ${this.disabled ? 'disabled' : ''}
@@ -253,6 +254,7 @@ export class ElDmAccordionItem extends BaseElement {
               part="content"
               id="content-${this.value || 'item'}"
               role="region"
+              aria-labelledby="trigger-${this.value || 'item'}"
               aria-hidden="${this.open ? 'false' : 'true'}"
             >
               <slot></slot>


### PR DESCRIPTION
## Summary
- Add `id` attribute on the trigger button (`trigger-{value}`)
- Add `aria-labelledby` on the content panel referencing the trigger button
- Existing `aria-expanded`, `aria-controls`, and `role="region"` were already in place

Fixes #9