### PR TITLE
fix(chip): support role forwarding and aria-selected

### DIFF
--- a/elements/chip/src/el-dm-chip.ts
+++ b/elements/chip/src/el-dm-chip.ts
@@ -254,7 +254,7 @@ export class ElDmChip extends BaseElement {
     const deleteIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>`;
 
     return `
-      <span class="${chipClasses}" part="chip" role="button" tabindex="0">
+      <span class="${chipClasses}" part="chip" role="${this.getAttribute('role') || 'button'}" tabindex="0"${this.selected ? ' aria-selected="true"' : ''}>
         <span class="chip-icon" part="icon">
           <slot name="icon"></slot>
         </span>


### PR DESCRIPTION
## Summary
- Forward host `role` attribute to inner chip span (falls back to `button` if not set)
- Add `aria-selected="true"` when chip is in selected state
- Enables usage as `role="option"` in listbox/combobox contexts

Fixes #13