### PR TITLE
fix(card): add role=article for non-interactive cards

### DIFF
--- a/elements/card/src/el-dm-card.ts
+++ b/elements/card/src/el-dm-card.ts
@@ -212,7 +212,7 @@ export class ElDmCard extends BaseElement {
     const cardClasses = this._getCardClasses();
 
     return `
-      <div class="${cardClasses}" part="card">
+      <div class="${cardClasses}" part="card"${!this.interactive ? ' role="article"' : ''}>
         <div class="card-image" part="media">
           <slot name="media"></slot>
         </div>


### PR DESCRIPTION
## Summary
- Add `role="article"` to the card container when the card is not interactive
- Interactive cards already get `role="button"` via `_setupInteractive()`
- Provides proper semantic landmark for screen readers

Fixes #14