### PR TITLE
fix(ci): resolve lint error and docs build path issue

### DIFF
--- a/elements/markdown-input/src/css.ts
+++ b/elements/markdown-input/src/css.ts
@@ -335,7 +335,7 @@ export const elementStyles = css`
   }
 
   /* When slot="bottom" is used, the slotted element fills the bar */
-  .status-bar > slot[name="bottom"]::slotted(*) {
+  .status-bar > slot[name='bottom']::slotted(*) {
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/elements/markdown-input/src/element.test.ts
+++ b/elements/markdown-input/src/element.test.ts
@@ -859,9 +859,7 @@ describe('ElDmMarkdownInput', () => {
       slottedEl.appendChild(toolbar);
       document.body.appendChild(slottedEl);
 
-      const slot = slottedEl.shadowRoot!.querySelector(
-        'slot[name="bottom"]',
-      ) as HTMLSlotElement;
+      const slot = slottedEl.shadowRoot!.querySelector('slot[name="bottom"]') as HTMLSlotElement;
       const assigned = slot?.assignedNodes?.() ?? [];
       expect(assigned.length).toBe(1);
       expect((assigned[0] as HTMLElement).querySelector('button')?.textContent).toBe('Send');

--- a/elements/markdown-input/src/element.test.ts
+++ b/elements/markdown-input/src/element.test.ts
@@ -909,7 +909,7 @@ describe('ElDmMarkdownInput', () => {
     test('attaching a file without upload-url stores it locally', () => {
       const file = makeFile('test.png', 'image/png');
       // Simulate the file input change event
-      const fileInput = el.shadowRoot!.querySelector('.file-input') as HTMLInputElement;
+      const _fileInput = el.shadowRoot!.querySelector('.file-input') as HTMLInputElement;
 
       // We can't set .files directly, so we call the internal method via event
       // Instead, test the public API approach — directly call insertFile behavior

--- a/elements/markdown-input/src/element.ts
+++ b/elements/markdown-input/src/element.ts
@@ -1136,9 +1136,7 @@ export class ElDmMarkdownInput extends BaseElement {
   #rebuildAttachedRows(): void {
     if (!this.#uploadList) return;
     // Remove all attached rows
-    this.#uploadList
-      .querySelectorAll('.upload-attached-row')
-      .forEach((r) => r.remove());
+    this.#uploadList.querySelectorAll('.upload-attached-row').forEach((r) => r.remove());
     // Re-add with correct indices
     this.#attachedFiles.forEach((file, i) => {
       const id = `upload-${++this.#uploadIdCounter}`;

--- a/packages/docs/src/layouts/DocsLayout.astro
+++ b/packages/docs/src/layouts/DocsLayout.astro
@@ -4,6 +4,7 @@ import ThemeToggle from '../components/ThemeToggle.astro';
 import Nav from '../components/Nav.astro';
 import MobileNav from '../components/MobileNav.astro';
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 interface Props {
   title: string;
@@ -13,7 +14,7 @@ interface Props {
 
 const { title, description, currentPath = Astro.url.pathname } = Astro.props;
 const isCssArt = currentPath.includes('/docs/art-elements');
-const pkg = JSON.parse(readFileSync(new URL('../../../base/package.json', import.meta.url), 'utf-8'));
+const pkg = JSON.parse(readFileSync(resolve(process.cwd(), '../base/package.json'), 'utf-8'));
 const version = `v${pkg.version}`;
 ---
 


### PR DESCRIPTION
## Summary

Fixes two CI failures affecting `main`:

1. **Lint failure** (`@duskmoon-dev/el-markdown-input`) — unused `fileInput` variable in test now prefixed with `_` to match ESLint `argsIgnorePattern: "^_"`

2. **Docs deployment failure** (`DocsLayout.astro`) — `readFileSync(new URL('../../../base/package.json', import.meta.url))` resolves incorrectly during Astro SSG because `import.meta.url` points to the `.prerender/chunks/` output directory, not the source file. Replaced with `resolve(process.cwd(), '../base/package.json')` which reliably resolves from the Astro project root.

## Test plan

- [ ] CI lint step passes
- [ ] Docs deployment builds and deploys successfully