### PR TITLE
fix: avoid dispatchEvent collision in elements register bundle

### DIFF
--- a/elements/markdown-input/src/render.ts
+++ b/elements/markdown-input/src/render.ts
@@ -76,6 +76,7 @@ export async function renderMarkdown(source: string): Promise<string> {
 // ── Mermaid post-render ─────────────────────────────────────────────────
 
 let mermaidIdCounter = 0;
+const bundledMermaidSpecifier = 'mermaid';
 
 /**
  * Detect the current theme by checking `data-theme` on `<html>`.
@@ -116,7 +117,7 @@ export async function renderMermaidBlocks(
   try {
     mermaidModule = mermaidSrc
       ? await import(/* @vite-ignore */ mermaidSrc)
-      : await import('mermaid');
+      : await import(/* @vite-ignore */ bundledMermaidSpecifier);
   } catch (err) {
     console.error('[el-dm-markdown-input] Failed to load mermaid: %o', err);
     blocks.forEach((block) => block.parentElement?.classList.add('mermaid-error'));

--- a/packages/elements/src/register-bundle.test.ts
+++ b/packages/elements/src/register-bundle.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+
+describe('@duskmoon-dev/elements/register bundle', () => {
+  test('does not inline mermaid d3 helpers into browser IIFE output', async () => {
+    const result = await Bun.build({
+      entrypoints: [new URL('./register.ts', import.meta.url).pathname],
+      format: 'iife',
+      target: 'browser',
+      write: false,
+    });
+
+    expect(result.success).toBe(true);
+    const output = await result.outputs[0].text();
+
+    expect(output).not.toContain('node_modules/.bun/d3-selection');
+    expect(output).not.toContain('function dispatchEvent(node');
+  });
+});

--- a/packages/elements/src/register.ts
+++ b/packages/elements/src/register.ts
@@ -13,6 +13,107 @@
  * // <el-dm-markdown>## Markdown</el-dm-markdown>
  * ```
  */
-import { registerAll } from './index.js';
+import { register as registerButton } from '@duskmoon-dev/el-button';
+import { register as registerCard } from '@duskmoon-dev/el-card';
+import { register as registerInput } from '@duskmoon-dev/el-input';
+import { register as registerMarkdown } from '@duskmoon-dev/el-markdown';
+import { register as registerSwitch } from '@duskmoon-dev/el-switch';
+import { register as registerAlert } from '@duskmoon-dev/el-alert';
+import { register as registerDialog } from '@duskmoon-dev/el-dialog';
+import { register as registerBadge } from '@duskmoon-dev/el-badge';
+import { register as registerChip } from '@duskmoon-dev/el-chip';
+import { register as registerTooltip } from '@duskmoon-dev/el-tooltip';
+import { register as registerProgress } from '@duskmoon-dev/el-progress';
+import { register as registerForm } from '@duskmoon-dev/el-form';
+import { register as registerSlider } from '@duskmoon-dev/el-slider';
+import { register as registerFileUpload } from '@duskmoon-dev/el-file-upload';
+import { register as registerAutocomplete } from '@duskmoon-dev/el-autocomplete';
+import { register as registerDatepicker } from '@duskmoon-dev/el-datepicker';
+import { register as registerSelect } from '@duskmoon-dev/el-select';
+import { register as registerCascader } from '@duskmoon-dev/el-cascader';
+import { register as registerBottomNavigation } from '@duskmoon-dev/el-bottom-navigation';
+import { register as registerCircleMenu } from '@duskmoon-dev/el-circle-menu';
+import { register as registerBreadcrumbs } from '@duskmoon-dev/el-breadcrumbs';
+import { register as registerDrawer } from '@duskmoon-dev/el-drawer';
+import { register as registerMenu } from '@duskmoon-dev/el-menu';
+import { register as registerNavbar } from '@duskmoon-dev/el-navbar';
+import { register as registerPagination } from '@duskmoon-dev/el-pagination';
+import { register as registerStepper } from '@duskmoon-dev/el-stepper';
+import { register as registerTabs } from '@duskmoon-dev/el-tabs';
+import { register as registerAccordion } from '@duskmoon-dev/el-accordion';
+import { register as registerBottomSheet } from '@duskmoon-dev/el-bottom-sheet';
+import { register as registerPopover } from '@duskmoon-dev/el-popover';
+import { register as registerTable } from '@duskmoon-dev/el-table';
+import {
+  registerGridColumn,
+  registerGridColumnGroup,
+  registerProDataGrid,
+} from '@duskmoon-dev/el-pro-data-grid';
+import { register as registerCodeBlock } from '@duskmoon-dev/el-code-block';
+import { register as registerFormGroup } from '@duskmoon-dev/el-form-group';
+import { register as registerNavigation } from '@duskmoon-dev/el-navigation';
+import { register as registerNestedMenu } from '@duskmoon-dev/el-nested-menu';
+import { register as registerOtpInput } from '@duskmoon-dev/el-otp-input';
+import { register as registerPinInput } from '@duskmoon-dev/el-pin-input';
+import { register as registerSegmentControl } from '@duskmoon-dev/el-segment-control';
+import { register as registerThemeController } from '@duskmoon-dev/el-theme-controller';
+import { register as registerTimeInput } from '@duskmoon-dev/el-time-input';
 
-registerAll();
+const markdownInputRegisterSpecifier = '@duskmoon-dev/el-markdown-input/register';
+const codeEngineRegisterSpecifier = '@duskmoon-dev/el-code-engine';
+
+function registerMarkdownInput(): void {
+  void import(/* @vite-ignore */ markdownInputRegisterSpecifier).catch(() => undefined);
+}
+
+function registerCodeEngine(): void {
+  void import(/* @vite-ignore */ codeEngineRegisterSpecifier)
+    .then(({ register }) => register())
+    .catch(() => undefined);
+}
+
+registerButton();
+registerCard();
+registerInput();
+registerMarkdown();
+registerSwitch();
+registerAlert();
+registerDialog();
+registerBadge();
+registerChip();
+registerTooltip();
+registerProgress();
+registerForm();
+registerSlider();
+registerFileUpload();
+registerAutocomplete();
+registerDatepicker();
+registerBottomNavigation();
+registerCircleMenu();
+registerBreadcrumbs();
+registerDrawer();
+registerMenu();
+registerNavbar();
+registerPagination();
+registerStepper();
+registerTabs();
+registerAccordion();
+registerBottomSheet();
+registerPopover();
+registerTable();
+registerProDataGrid();
+registerGridColumn();
+registerGridColumnGroup();
+registerMarkdownInput();
+registerSelect();
+registerCascader();
+registerCodeBlock();
+registerCodeEngine();
+registerFormGroup();
+registerNavigation();
+registerNestedMenu();
+registerOtpInput();
+registerPinInput();
+registerSegmentControl();
+registerThemeController();
+registerTimeInput();


### PR DESCRIPTION
## Summary
- keep @duskmoon-dev/elements/register off the root aggregate index so side-effect imports do not inline MarkdownInput's Mermaid/D3 stack
- keep MarkdownInput's Mermaid fallback as a runtime dynamic import
- add an IIFE bundle regression test that rejects the d3-selection dispatchEvent helper

Fixes #53