### PR TITLE
fix: support cmd enter chat submit

### DIFF
--- a/elements/chat/src/el-dm-chat.test.ts
+++ b/elements/chat/src/el-dm-chat.test.ts
@@ -249,4 +249,27 @@ describe('chat elements', () => {
     const sendEvent = await event;
     expect(sendEvent.detail).toEqual({ value: 'Keyboard send' });
   });
+
+  test('sends from markdown chat input on cmd enter', async () => {
+    const el = document.createElement('el-dm-chat-input') as ElDmChatInput;
+    container.appendChild(el);
+
+    el.setValue('Mac keyboard send');
+
+    const event = new Promise<CustomEvent>((resolve) => {
+      el.addEventListener('send', (sendEvent) => resolve(sendEvent as CustomEvent));
+    });
+
+    el.shadowRoot?.dispatchEvent(
+      new window.KeyboardEvent('keydown', {
+        key: 'Enter',
+        metaKey: true,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+
+    const sendEvent = await event;
+    expect(sendEvent.detail).toEqual({ value: 'Mac keyboard send' });
+  });
 });

--- a/elements/chat/src/el-dm-chat.ts
+++ b/elements/chat/src/el-dm-chat.ts
@@ -727,7 +727,11 @@ export class ElDmChatInput extends BaseElement {
   static properties = {
     name: { type: String, reflect: true, default: '' },
     value: { type: String },
-    placeholder: { type: String, reflect: true, default: 'Send a message... (Ctrl+Enter to send)' },
+    placeholder: {
+      type: String,
+      reflect: true,
+      default: 'Send a message... (Ctrl/Cmd+Enter to send)',
+    },
     disabled: { type: Boolean, reflect: true },
     readonly: { type: Boolean, reflect: true },
     sendLabel: { type: String, reflect: true, attribute: 'send-label', default: 'Send' },
@@ -782,7 +786,13 @@ export class ElDmChatInput extends BaseElement {
 
   private _handleKeyDown = (event: Event): void => {
     const keyboardEvent = event as KeyboardEvent;
-    if (keyboardEvent.key !== 'Enter' || !keyboardEvent.ctrlKey || keyboardEvent.shiftKey) return;
+    if (
+      keyboardEvent.key !== 'Enter' ||
+      (!keyboardEvent.ctrlKey && !keyboardEvent.metaKey) ||
+      keyboardEvent.shiftKey
+    ) {
+      return;
+    }
     if (this.disabled || this.readonly) return;
 
     keyboardEvent.preventDefault();
@@ -806,7 +816,7 @@ export class ElDmChatInput extends BaseElement {
           part="editor"
           name="${escapeHtml(this.name || '')}"
           value="${escapeHtml(this.value || '')}"
-          placeholder="${escapeHtml(this.placeholder || 'Send a message... (Ctrl+Enter to send)')}"
+          placeholder="${escapeHtml(this.placeholder || 'Send a message... (Ctrl/Cmd+Enter to send)')}"
           resize="vertical"
           no-preview
           ${this.disabled ? 'disabled' : ''}


### PR DESCRIPTION
## Summary
- accept Cmd+Enter/metaKey as a send shortcut for el-dm-chat-input
- update the default shortcut hint to mention Ctrl/Cmd+Enter
- add regression coverage for Cmd+Enter submit

Fixes #56