### PR TITLE
fix: support external button forms

### DIFF
--- a/elements/button/src/el-dm-button.test.ts
+++ b/elements/button/src/el-dm-button.test.ts
@@ -78,6 +78,25 @@ describe('ElDmButton', () => {
     expect(button?.getAttribute('type')).toBe('button');
   });
 
+  test('submits external form referenced by form attribute', () => {
+    const form = document.createElement('form');
+    form.id = 'external-form';
+    let submitted = false;
+    form.requestSubmit = () => {
+      submitted = true;
+    };
+    container.appendChild(form);
+
+    const el = document.createElement('el-dm-button') as ElDmButton;
+    el.type = 'submit';
+    el.setAttribute('form', 'external-form');
+    container.appendChild(el);
+
+    el.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+    expect(submitted).toBe(true);
+  });
+
   test('supports prefix and suffix slots', () => {
     const el = document.createElement('el-dm-button') as ElDmButton;
     container.appendChild(el);

--- a/elements/button/src/el-dm-button.ts
+++ b/elements/button/src/el-dm-button.ts
@@ -135,16 +135,26 @@ export class ElDmButton extends BaseElement {
 
     // Handle form submission
     if (this.type === 'submit') {
-      const form = this.closest('form');
+      const form = this._getAssociatedForm();
       if (form) {
         form.requestSubmit();
       }
     } else if (this.type === 'reset') {
-      const form = this.closest('form');
+      const form = this._getAssociatedForm();
       if (form) {
         form.reset();
       }
     }
+  }
+
+  private _getAssociatedForm(): HTMLFormElement | null {
+    const formId = this.getAttribute('form');
+    if (formId) {
+      const form = this.ownerDocument.getElementById(formId);
+      return form?.tagName === 'FORM' ? (form as HTMLFormElement) : null;
+    }
+
+    return this.closest('form');
   }
 
   connectedCallback(): void {


### PR DESCRIPTION
## Summary
- resolve el-dm-button associated forms through the HTML form attribute
- preserve nearest ancestor form fallback for nested buttons
- add regression coverage for external submit buttons

Fixes #59