### PR TITLE
fix: inherit filled chat bubble text color

### DIFF
--- a/elements/chat/src/el-dm-chat.test.ts
+++ b/elements/chat/src/el-dm-chat.test.ts
@@ -29,6 +29,16 @@ register();
 describe('chat elements', () => {
   let container: HTMLDivElement;
 
+  function getAdoptedCSS(el: HTMLElement): string {
+    return (el.shadowRoot?.adoptedStyleSheets ?? [])
+      .map((sheet) =>
+        Array.from(sheet.cssRules)
+          .map((rule) => rule.cssText)
+          .join('\n'),
+      )
+      .join('\n');
+  }
+
   beforeEach(() => {
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -65,6 +75,21 @@ describe('chat elements', () => {
     expect(bubble?.classList.contains('chat-bubble-filled')).toBe(true);
     expect(bubble?.classList.contains('chat-bubble-lg')).toBe(true);
     expect(bubble?.classList.contains('chat-bubble-streaming')).toBe(true);
+  });
+
+  test('sets host text color for filled colored bubbles', () => {
+    const el = document.createElement('el-dm-chat') as ElDmChat;
+    el.color = 'primary';
+    el.variant = 'filled';
+    container.appendChild(el);
+
+    const css = getAdoptedCSS(el);
+
+    expect(css).toContain("variant='filled'");
+    expect(css).toContain("color='primary'");
+    expect(css).toContain('--color-primary-content');
+    expect(css).toContain("color='success'");
+    expect(css).toContain('--color-success-content');
   });
 
   test('renders avatar, status, and quick actions', async () => {

--- a/elements/chat/src/el-dm-chat.ts
+++ b/elements/chat/src/el-dm-chat.ts
@@ -83,6 +83,34 @@ const styles = css`
 
   ${coreStyles}
 
+  :host([variant='filled'][color='primary']) {
+    color: var(--color-primary-content);
+  }
+
+  :host([variant='filled'][color='secondary']) {
+    color: var(--color-secondary-content);
+  }
+
+  :host([variant='filled'][color='tertiary']) {
+    color: var(--color-tertiary-content);
+  }
+
+  :host([variant='filled'][color='info']) {
+    color: var(--color-info-content);
+  }
+
+  :host([variant='filled'][color='success']) {
+    color: var(--color-success-content);
+  }
+
+  :host([variant='filled'][color='warning']) {
+    color: var(--color-warning-content);
+  }
+
+  :host([variant='filled'][color='error']) {
+    color: var(--color-error-content);
+  }
+
   .chat-avatar,
   .chat-header,
   .chat-footer,


### PR DESCRIPTION
## Summary
- Add filled color host rules for chat bubbles so slotted web components inherit the correct foreground color
- Cover primary and semantic filled color host styles in chat tests

Fixes #62