### PR TITLE
fix: resolve internal component integration requests

### DIFF
--- a/.changeset/calm-moons-fix-internal-requests.md
+++ b/.changeset/calm-moons-fix-internal-requests.md
@@ -1,0 +1,12 @@
+---
+"@duskmoon-dev/el-breadcrumbs": patch
+"@duskmoon-dev/el-button": patch
+"@duskmoon-dev/el-code-engine": patch
+"@duskmoon-dev/el-markdown": patch
+"@duskmoon-dev/el-pagination": patch
+"@duskmoon-dev/el-popover": patch
+"@duskmoon-dev/elements": patch
+---
+
+Fix internal integration requests across form submission, CodeMirror themes, safe Markdown
+rendering, declarative server navigation, and popover focus restoration.

--- a/elements/breadcrumbs/src/el-dm-breadcrumbs.test.ts
+++ b/elements/breadcrumbs/src/el-dm-breadcrumbs.test.ts
@@ -69,6 +69,52 @@ describe('ElDmBreadcrumbs', () => {
     expect(items?.length).toBe(0);
   });
 
+  test('projects declarative server-rendered items without replacing their anchors', () => {
+    const el = createBreadcrumbs();
+    const items = ['/docs', '/docs/components', '/docs/components/breadcrumbs'].map(
+      (href, index) => {
+        const item = document.createElement('span');
+        item.slot = 'item';
+        const link = document.createElement('a');
+        link.href = href;
+        link.setAttribute('data-phx-link', 'patch');
+        link.textContent = `Crumb ${index + 1}`;
+        item.appendChild(link);
+        el.appendChild(item);
+        return item;
+      },
+    );
+    container.appendChild(el);
+
+    const slot = el.shadowRoot?.querySelector('slot[name="item"]') as HTMLSlotElement;
+    expect(slot.assignedElements()).toEqual(items);
+    expect(items[0].querySelector('a')?.getAttribute('href')).toBe('/docs');
+    expect(items[0].querySelector('a')?.getAttribute('data-phx-link')).toBe('patch');
+    expect(items[2].getAttribute('aria-current')).toBe('page');
+    expect(items[0].getAttribute('aria-current')).toBeNull();
+  });
+
+  test('does not intercept declarative item navigation', () => {
+    const el = createBreadcrumbs();
+    const item = document.createElement('span');
+    item.slot = 'item';
+    const link = document.createElement('a');
+    link.href = '/server-page';
+    item.appendChild(link);
+    el.appendChild(item);
+    container.appendChild(el);
+
+    let navigated = false;
+    el.addEventListener('navigate', () => {
+      navigated = true;
+    });
+    const click = new window.MouseEvent('click', { bubbles: true, cancelable: true });
+    link.dispatchEvent(click);
+
+    expect(click.defaultPrevented).toBe(false);
+    expect(navigated).toBe(false);
+  });
+
   // --- Item rendering ---
   test('non-last items are rendered as links', () => {
     const el = createBreadcrumbs({ items: sampleItems });

--- a/elements/breadcrumbs/src/el-dm-breadcrumbs.ts
+++ b/elements/breadcrumbs/src/el-dm-breadcrumbs.ts
@@ -9,6 +9,7 @@
  * @attr {string} items - JSON array of breadcrumb items [{label, href}]
  * @attr {string} separator - Separator character between items (default '/')
  *
+ * @slot item - Declarative server-rendered breadcrumb item
  * @slot separator - Custom separator element to use between items
  *
  * @csspart nav - The navigation container
@@ -102,6 +103,18 @@ const styles = css`
   ::slotted([slot='separator']) {
     display: none;
   }
+
+  ::slotted([slot='item']) {
+    display: inline-flex;
+    align-items: center;
+    color: var(--color-primary);
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+  }
+
+  ::slotted([slot='item'][aria-current='page']) {
+    color: var(--color-on-surface);
+  }
 `;
 
 export class ElDmBreadcrumbs extends BaseElement {
@@ -115,6 +128,8 @@ export class ElDmBreadcrumbs extends BaseElement {
 
   /** Separator character between items */
   declare separator: string;
+
+  private _itemsObserver?: MutationObserver;
 
   constructor() {
     super();
@@ -160,7 +175,42 @@ export class ElDmBreadcrumbs extends BaseElement {
     return div.innerHTML;
   }
 
+  private _hasDeclarativeItems(): boolean {
+    return this.querySelector('[slot="item"]') !== null;
+  }
+
+  private _syncDeclarativeItems = (): void => {
+    const slot = this.shadowRoot?.querySelector('slot[name="item"]') as HTMLSlotElement | null;
+    const items = slot?.assignedElements() ?? [];
+
+    items.forEach((item, index) => {
+      item.setAttribute('role', 'listitem');
+      if (index === items.length - 1) {
+        item.setAttribute('aria-current', 'page');
+      } else {
+        item.removeAttribute('aria-current');
+      }
+    });
+  };
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this._itemsObserver = new MutationObserver(() => this.update());
+    this._itemsObserver.observe(this, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['slot'],
+    });
+  }
+
+  disconnectedCallback(): void {
+    this._itemsObserver?.disconnect();
+    super.disconnectedCallback();
+  }
+
   render(): string {
+    const declarativeItems = this._hasDeclarativeItems();
     const itemsArray = Array.isArray(this.items) ? this.items : [];
     const separatorHtml = this._getSeparatorHtml();
 
@@ -200,7 +250,7 @@ export class ElDmBreadcrumbs extends BaseElement {
     return `
       <nav class="breadcrumbs-nav" part="nav" aria-label="Breadcrumb">
         <ol class="breadcrumbs" part="list">
-          ${itemsHtml}
+          ${declarativeItems ? '<slot name="item"></slot>' : itemsHtml}
         </ol>
         <slot name="separator"></slot>
       </nav>
@@ -209,6 +259,12 @@ export class ElDmBreadcrumbs extends BaseElement {
 
   update(): void {
     super.update();
+
+    const itemSlot = this.shadowRoot?.querySelector('slot[name="item"]');
+    itemSlot?.addEventListener('slotchange', this._syncDeclarativeItems);
+    this._syncDeclarativeItems();
+
+    if (this._hasDeclarativeItems()) return;
 
     // Attach click handlers to all breadcrumb links
     const links = this.shadowRoot?.querySelectorAll('.breadcrumb-link');

--- a/elements/button/src/el-dm-button.test.ts
+++ b/elements/button/src/el-dm-button.test.ts
@@ -81,20 +81,27 @@ describe('ElDmButton', () => {
   test('submits external form referenced by form attribute', () => {
     const form = document.createElement('form');
     form.id = 'external-form';
-    let submitted = false;
-    form.requestSubmit = () => {
-      submitted = true;
+    let submitter: HTMLElement | undefined;
+    form.requestSubmit = (button) => {
+      submitter = button;
+      expect(button?.isConnected).toBe(true);
+      expect(button?.form).toBe(form);
     };
     container.appendChild(form);
 
     const el = document.createElement('el-dm-button') as ElDmButton;
     el.type = 'submit';
     el.setAttribute('form', 'external-form');
+    el.setAttribute('name', 'action');
+    el.setAttribute('value', 'save');
     container.appendChild(el);
 
     el.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
 
-    expect(submitted).toBe(true);
+    expect(submitter?.getAttribute('name')).toBe('action');
+    expect(submitter?.getAttribute('value')).toBe('save');
+    expect(submitter?.isConnected).toBe(false);
+    expect(form.querySelector('button')).toBeNull();
   });
 
   test('supports prefix and suffix slots', () => {

--- a/elements/button/src/el-dm-button.ts
+++ b/elements/button/src/el-dm-button.ts
@@ -137,7 +137,30 @@ export class ElDmButton extends BaseElement {
     if (this.type === 'submit') {
       const form = this._getAssociatedForm();
       if (form) {
-        form.requestSubmit();
+        const submitter = this.ownerDocument.createElement('button');
+        submitter.type = 'submit';
+        submitter.hidden = true;
+
+        for (const attribute of [
+          'name',
+          'value',
+          'formaction',
+          'formenctype',
+          'formmethod',
+          'formnovalidate',
+          'formtarget',
+        ]) {
+          if (this.hasAttribute(attribute)) {
+            submitter.setAttribute(attribute, this.getAttribute(attribute) ?? '');
+          }
+        }
+
+        form.appendChild(submitter);
+        try {
+          form.requestSubmit(submitter);
+        } finally {
+          submitter.remove();
+        }
       }
     } else if (this.type === 'reset') {
       const form = this._getAssociatedForm();

--- a/elements/code-engine/src/el-dm-code-engine.test.ts
+++ b/elements/code-engine/src/el-dm-code-engine.test.ts
@@ -6,13 +6,17 @@ import { describe, it, expect, beforeAll, afterEach, mock } from 'bun:test';
 // and DOM structure, so we stub out the editor internals.
 
 class FakeCompartment {
-  of(_ext: unknown) {
+  of(ext: unknown) {
+    configuredExtensions.push(ext);
     return [];
   }
   reconfigure(_ext: unknown) {
     return {};
   }
 }
+
+const configuredExtensions: unknown[] = [];
+const oneDarkExtension = { extension: 'one-dark' };
 
 const fakeEditorState = {
   readOnly: { of: () => ({}) },
@@ -49,10 +53,13 @@ mock.module('@duskmoon-dev/code-engine/commands', () => ({
   redo: () => {},
 }));
 
-mock.module('@duskmoon-dev/code-engine/theme/duskmoon', () => ({ default: () => [] }));
-mock.module('@duskmoon-dev/code-engine/theme/sunshine', () => ({ default: () => [] }));
-mock.module('@duskmoon-dev/code-engine/theme/moonlight', () => ({ default: () => [] }));
-mock.module('@duskmoon-dev/code-engine/theme/one-dark', () => ({ default: () => [] }));
+mock.module('@duskmoon-dev/code-engine/theme/duskmoon', () => ({ duskMoon: () => [] }));
+mock.module('@duskmoon-dev/code-engine/theme/sunshine', () => ({ sunshine: [] }));
+mock.module('@duskmoon-dev/code-engine/theme/moonlight', () => ({ moonlight: [] }));
+mock.module('@duskmoon-dev/code-engine/theme/one-dark', () => ({
+  color: { background: '#282c34' },
+  oneDark: oneDarkExtension,
+}));
 
 // Now import the element class (after mocks are in place)
 const { ElDmCodeEngine } = await import('./el-dm-code-engine.js');
@@ -91,6 +98,15 @@ async function flush(): Promise<void> {
 }
 
 describe('ElDmCodeEngine', () => {
+  it('uses the one-dark extension instead of its exported color map', async () => {
+    configuredExtensions.length = 0;
+    createElement({ theme: 'one-dark' });
+    await flush();
+
+    expect(configuredExtensions).toContain(oneDarkExtension);
+    expect(configuredExtensions).not.toContainEqual({ background: '#282c34' });
+  });
+
   describe('properties', () => {
     it('should have showTopbar default to false', async () => {
       const el = createElement();

--- a/elements/code-engine/src/el-dm-code-engine.ts
+++ b/elements/code-engine/src/el-dm-code-engine.ts
@@ -47,25 +47,16 @@ import { basicSetup } from '@duskmoon-dev/code-engine/setup';
 import { undo, redo } from '@duskmoon-dev/code-engine/commands';
 
 // ── Static theme imports (all 4 are small; avoids runtime bare-specifier issues) ──
-import * as _duskmoonTheme from '@duskmoon-dev/code-engine/theme/duskmoon';
-import * as _sunshineTheme from '@duskmoon-dev/code-engine/theme/sunshine';
-import * as _moonlightTheme from '@duskmoon-dev/code-engine/theme/moonlight';
-import * as _oneDarkTheme from '@duskmoon-dev/code-engine/theme/one-dark';
-
-function extractExt(mod: Record<string, unknown>): Extension {
-  const v =
-    mod.default ??
-    Object.values(mod).find((x) => typeof x === 'function' || (x && typeof x !== 'string'));
-  // Theme modules export a factory function (e.g. duskMoon(options?))
-  if (typeof v === 'function') return (v as () => Extension)() as Extension;
-  return (v ?? []) as Extension;
-}
+import { duskMoon } from '@duskmoon-dev/code-engine/theme/duskmoon';
+import { sunshine } from '@duskmoon-dev/code-engine/theme/sunshine';
+import { moonlight } from '@duskmoon-dev/code-engine/theme/moonlight';
+import { oneDark } from '@duskmoon-dev/code-engine/theme/one-dark';
 
 const THEMES: Record<string, Extension> = {
-  duskmoon: extractExt(_duskmoonTheme as unknown as Record<string, unknown>),
-  sunshine: extractExt(_sunshineTheme as unknown as Record<string, unknown>),
-  moonlight: extractExt(_moonlightTheme as unknown as Record<string, unknown>),
-  'one-dark': extractExt(_oneDarkTheme as unknown as Record<string, unknown>),
+  duskmoon: duskMoon(),
+  sunshine,
+  moonlight,
+  'one-dark': oneDark,
 };
 
 // ── Language loaders (literal import paths so bundlers can resolve them) ──

--- a/elements/markdown/package.json
+++ b/elements/markdown/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@duskmoon-dev/core": "1.17.0",
     "@duskmoon-dev/el-base": "1.5.3",
+    "dompurify": "3.3.3",
     "highlight.js": "11.11.1",
     "marked": "18.0.4",
     "marked-highlight": "2.2.4"

--- a/elements/markdown/src/el-dm-markdown.test.ts
+++ b/elements/markdown/src/el-dm-markdown.test.ts
@@ -127,6 +127,30 @@ describe('ElDmMarkdown', () => {
 
     expect(el.shadowRoot?.querySelector('.color-chip')).toBeNull();
   });
+
+  test('sanitizes raw HTML, event handlers, and unsafe URLs by default', async () => {
+    const el = document.createElement('el-dm-markdown') as ElDmMarkdown;
+    container.appendChild(el);
+    el.content =
+      '<img src="javascript:alert(1)" onerror="alert(1)"><script>alert(1)</script>' +
+      '[unsafe](javascript:alert(1))';
+    await Promise.resolve();
+
+    const html = el.shadowRoot?.querySelector('.content')?.innerHTML ?? '';
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('onerror');
+    expect(html).not.toContain('javascript:');
+  });
+
+  test('allows trusted callers to opt out of sanitization explicitly', async () => {
+    const el = document.createElement('el-dm-markdown') as ElDmMarkdown;
+    el.sanitize = false;
+    container.appendChild(el);
+    el.content = '<span data-trusted="true">Trusted</span>';
+    await Promise.resolve();
+
+    expect(el.shadowRoot?.querySelector('[data-trusted="true"]')).not.toBeNull();
+  });
 });
 
 describe('Theme exports', () => {
@@ -224,6 +248,17 @@ describe('Streaming API', () => {
 
     const cursor = el.shadowRoot?.querySelector('.streaming-cursor');
     expect(cursor).toBeNull();
+  });
+
+  test('sanitizes streamed markdown before inserting it into the DOM', async () => {
+    el.startStreaming();
+    el.appendContent('<img src="javascript:alert(1)" onerror="alert(1)">');
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+
+    const html = el.shadowRoot?.querySelector('.content')?.innerHTML ?? '';
+    expect(html).not.toContain('onerror');
+    expect(html).not.toContain('javascript:');
   });
 
   test('emits dm-stream-chunk event', () => {

--- a/elements/markdown/src/el-dm-markdown.ts
+++ b/elements/markdown/src/el-dm-markdown.ts
@@ -11,6 +11,7 @@
  * @attr {string} theme - Code theme: github, atom-one-dark, atom-one-light (default: auto)
  * @attr {boolean} debug - Enable debug logging
  * @attr {boolean} no-mermaid - Disable mermaid diagram rendering
+ * @attr {boolean} sanitize - Sanitize rendered HTML (default: true)
  * @attr {boolean} streaming - Read-only attribute reflecting streaming state
  *
  * @prop {string} content - Get/set markdown content directly
@@ -44,6 +45,7 @@ import { css as markdownBodyCSS } from '@duskmoon-dev/core/components/markdown-b
 import { Marked } from 'marked';
 import { markedHighlight } from 'marked-highlight';
 import hljs from 'highlight.js';
+import DOMPurify from 'dompurify';
 
 import { github } from './themes/github.js';
 import { atomOneDark } from './themes/atom-one-dark.js';
@@ -67,6 +69,34 @@ function isSupportedColor(value: string): boolean {
 
   const hsl = /^hsl\(\s*(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%\s*\)$/.exec(value);
   return Boolean(hsl && Number(hsl[1]) <= 360 && Number(hsl[2]) <= 100 && Number(hsl[3]) <= 100);
+}
+
+function isSafeUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+
+  try {
+    const url = new URL(trimmed, document.baseURI);
+    return ['http:', 'https:', 'mailto:', 'tel:'].includes(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeHtml(html: string): string {
+  const template = document.createElement('template');
+  template.innerHTML = DOMPurify.sanitize(html);
+
+  for (const element of template.content.querySelectorAll('*')) {
+    for (const attribute of ['href', 'src', 'xlink:href']) {
+      const value = element.getAttribute(attribute);
+      if (value !== null && !isSafeUrl(value)) {
+        element.removeAttribute(attribute);
+      }
+    }
+  }
+
+  return template.innerHTML;
 }
 
 // Create a marked instance with GFM + syntax highlighting
@@ -233,6 +263,7 @@ export class ElDmMarkdown extends BaseElement {
     theme: { type: String, reflect: true, default: 'auto' },
     debug: { type: Boolean, reflect: true },
     noMermaid: { type: Boolean, reflect: true, attribute: 'no-mermaid' },
+    sanitize: { type: Boolean, reflect: true, default: true },
     streaming: { type: Boolean, reflect: true },
   };
 
@@ -251,6 +282,9 @@ export class ElDmMarkdown extends BaseElement {
 
   /** Disable mermaid rendering */
   declare noMermaid: boolean;
+
+  /** Sanitize rendered HTML. Set false only for trusted content. */
+  declare sanitize: boolean;
 
   /** Streaming state (reflected as attribute) */
   declare streaming: boolean;
@@ -498,7 +532,8 @@ export class ElDmMarkdown extends BaseElement {
     }
 
     try {
-      this._fragment = markedInstance.parse(this._content) as string;
+      const parsed = markedInstance.parse(this._content) as string;
+      this._fragment = this.sanitize ? sanitizeHtml(parsed) : parsed;
       this.update();
 
       // Process mermaid diagrams after render
@@ -638,7 +673,8 @@ export class ElDmMarkdown extends BaseElement {
         );
       }
 
-      this._fragment = markedInstance.parse(fixedContent) as string;
+      const parsed = markedInstance.parse(fixedContent) as string;
+      this._fragment = this.sanitize ? sanitizeHtml(parsed) : parsed;
       this.update();
 
       // Process mermaid diagrams after render (but skip during heavy streaming)

--- a/elements/pagination/src/el-dm-pagination.test.ts
+++ b/elements/pagination/src/el-dm-pagination.test.ts
@@ -55,6 +55,60 @@ describe('ElDmPagination', () => {
     expect(navBtns?.length).toBe(4);
   });
 
+  test('projects declarative server controls and preserves their attributes', () => {
+    const el = createPagination({ total: 3, current: 2 });
+    const previous = document.createElement('a');
+    previous.slot = 'prev';
+    previous.href = '/pages/1';
+    previous.setAttribute('data-phx-link', 'patch');
+    const current = document.createElement('a');
+    current.slot = 'page';
+    current.href = '/pages/2';
+    current.setAttribute('aria-current', 'page');
+    const ellipsis = document.createElement('span');
+    ellipsis.slot = 'page';
+    ellipsis.textContent = '…';
+    const next = document.createElement('a');
+    next.slot = 'next';
+    next.href = '/pages/3';
+    el.append(previous, current, ellipsis, next);
+    container.appendChild(el);
+
+    const pageSlot = el.shadowRoot?.querySelector('slot[name="page"]') as HTMLSlotElement;
+    expect(pageSlot.assignedElements()).toEqual([current, ellipsis]);
+    expect(el.shadowRoot?.querySelector('.nav-btn')).toBeNull();
+    expect(previous.getAttribute('href')).toBe('/pages/1');
+    expect(previous.getAttribute('data-phx-link')).toBe('patch');
+    expect(current.getAttribute('aria-current')).toBe('page');
+  });
+
+  test('does not intercept declarative navigation', () => {
+    const el = createPagination({ total: 3, current: 2 });
+    const next = document.createElement('a');
+    next.slot = 'next';
+    next.href = '/pages/3';
+    el.appendChild(next);
+    container.appendChild(el);
+
+    let changed = false;
+    el.addEventListener('change', () => {
+      changed = true;
+    });
+    const click = new window.MouseEvent('click', { bubbles: true, cancelable: true });
+    next.dispatchEvent(click);
+    const keydown = new window.KeyboardEvent('keydown', {
+      key: 'ArrowRight',
+      bubbles: true,
+      cancelable: true,
+    });
+    next.dispatchEvent(keydown);
+
+    expect(click.defaultPrevented).toBe(false);
+    expect(keydown.defaultPrevented).toBe(false);
+    expect(el.current).toBe(2);
+    expect(changed).toBe(false);
+  });
+
   // --- Properties ---
   test('defaults total to 1', () => {
     const el = createPagination();

--- a/elements/pagination/src/el-dm-pagination.ts
+++ b/elements/pagination/src/el-dm-pagination.ts
@@ -13,6 +13,11 @@
  * @attr {string} size - Button size: xs, sm, md, lg
  * @attr {string} color - Color variant: primary, secondary, neutral
  *
+ * @slot prev - Declarative server-rendered previous-page control
+ * @slot previous - Alias for the declarative previous-page control
+ * @slot page - Declarative server-rendered page or ellipsis control
+ * @slot next - Declarative server-rendered next-page control
+ *
  * @csspart container - The pagination container
  * @csspart button - Navigation buttons (first, prev, next, last)
  * @csspart page - Page number buttons
@@ -104,6 +109,36 @@ const styles = css`
     color: var(--color-text-muted, #6b7280);
     font-size: 0.875rem;
     user-select: none;
+  }
+
+  ::slotted([slot='prev']),
+  ::slotted([slot='previous']),
+  ::slotted([slot='page']),
+  ::slotted([slot='next']) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+    height: 2rem;
+    padding: 0 0.5rem;
+    border: 1px solid var(--color-border, #d1d5db);
+    border-radius: var(--radius-md, 0.375rem);
+    color: var(--color-text, #374151);
+    font: inherit;
+    text-decoration: none;
+  }
+
+  ::slotted([slot='page'][aria-current='page']),
+  ::slotted([slot='page'][data-active='true']) {
+    border-color: var(--color-primary, #3b82f6);
+    background: var(--color-primary, #3b82f6);
+    color: var(--color-primary-contrast, #ffffff);
+  }
+
+  ::slotted([disabled]),
+  ::slotted([aria-disabled='true']) {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   /* Size variants */
@@ -205,6 +240,8 @@ export class ElDmPagination extends BaseElement {
   /** Color variant: primary, secondary, neutral */
   declare color: PaginationColor;
 
+  private _controlsObserver?: MutationObserver;
+
   constructor() {
     super();
     this.attachStyles(styles);
@@ -214,6 +251,18 @@ export class ElDmPagination extends BaseElement {
     super.connectedCallback();
     this.addEventListener('click', this._handleClick.bind(this));
     this.addEventListener('keydown', this._handleKeydown.bind(this));
+    this._controlsObserver = new MutationObserver(() => this.update());
+    this._controlsObserver.observe(this, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['slot'],
+    });
+  }
+
+  disconnectedCallback(): void {
+    this._controlsObserver?.disconnect();
+    super.disconnectedCallback();
   }
 
   /**
@@ -275,6 +324,12 @@ export class ElDmPagination extends BaseElement {
     return pages;
   }
 
+  private _hasDeclarativeControls(): boolean {
+    return (
+      this.querySelector('[slot="prev"], [slot="previous"], [slot="page"], [slot="next"]') !== null
+    );
+  }
+
   /**
    * Navigate to a specific page
    */
@@ -290,6 +345,8 @@ export class ElDmPagination extends BaseElement {
    * Handle click events on pagination buttons
    */
   private _handleClick(event: Event): void {
+    if (this._hasDeclarativeControls()) return;
+
     const target = event.target as HTMLElement;
     const button = target.closest('button');
 
@@ -315,6 +372,8 @@ export class ElDmPagination extends BaseElement {
    * Handle keyboard navigation
    */
   private _handleKeydown(event: KeyboardEvent): void {
+    if (this._hasDeclarativeControls()) return;
+
     switch (event.key) {
       case 'ArrowLeft':
         event.preventDefault();
@@ -336,6 +395,17 @@ export class ElDmPagination extends BaseElement {
   }
 
   render(): string {
+    if (this._hasDeclarativeControls()) {
+      return `
+        <nav class="pagination" part="container" role="navigation" aria-label="Pagination">
+          <slot name="previous"></slot>
+          <slot name="prev"></slot>
+          <slot name="page"></slot>
+          <slot name="next"></slot>
+        </nav>
+      `;
+    }
+
     const total = Math.max(1, this.total);
     const current = Math.min(Math.max(1, this.current), total);
     const pages = this._getPageRange();

--- a/elements/popover/src/el-dm-popover.test.ts
+++ b/elements/popover/src/el-dm-popover.test.ts
@@ -257,6 +257,48 @@ describe('ElDmPopover', () => {
     expect(fired).toBe(true);
   });
 
+  test('uses a focusable descendant for trigger aria and Escape focus restoration', () => {
+    const el = createPopover();
+    const wrapper = document.createElement('span');
+    wrapper.slot = 'trigger';
+    const button = document.createElement('button');
+    button.textContent = 'Open';
+    wrapper.appendChild(button);
+    el.appendChild(wrapper);
+    container.appendChild(el);
+
+    el.show();
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(el.open).toBe(false);
+    expect(document.activeElement).toBe(button);
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('Escape focus restoration does not reopen a focus-triggered popover', async () => {
+    const el = createPopover({ trigger: 'focus' });
+    const wrapper = document.createElement('span');
+    wrapper.slot = 'trigger';
+    const button = document.createElement('button');
+    wrapper.appendChild(button);
+    const action = document.createElement('button');
+    action.textContent = 'Popover action';
+    el.appendChild(wrapper);
+    el.appendChild(action);
+    container.appendChild(el);
+
+    button.focus();
+    expect(el.open).toBe(true);
+    action.focus();
+    document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await Promise.resolve();
+
+    expect(document.activeElement).toBe(button);
+    expect(el.open).toBe(false);
+  });
+
   // --- Cleanup ---
   test('removes listeners on disconnect', () => {
     const el = createPopover();

--- a/elements/popover/src/el-dm-popover.ts
+++ b/elements/popover/src/el-dm-popover.ts
@@ -158,6 +158,7 @@ export class ElDmPopover extends BaseElement {
   private _boundUpdatePosition: () => void;
   private _hoverTimeout: number | null = null;
   private _currentPlacement: PopoverPlacement = 'bottom';
+  private _restoringFocus = false;
 
   constructor() {
     super();
@@ -252,7 +253,7 @@ export class ElDmPopover extends BaseElement {
   }
 
   private _attachTriggerEvents(): void {
-    const triggerEl = this._getTriggerElement();
+    const triggerEl = this._getAssignedTriggerElement();
     if (!triggerEl) return;
 
     // Remove any existing listeners first
@@ -286,13 +287,13 @@ export class ElDmPopover extends BaseElement {
   }
 
   private _removeTriggerListeners(): void {
-    const triggerEl = this._getTriggerElement();
+    const triggerEl = this._getAssignedTriggerElement();
     if (triggerEl) {
       this._detachTriggerEvents(triggerEl);
     }
   }
 
-  private _getTriggerElement(): Element | null {
+  private _getAssignedTriggerElement(): Element | null {
     const triggerSlot = this.shadowRoot?.querySelector(
       'slot[name="trigger"]',
     ) as HTMLSlotElement | null;
@@ -300,6 +301,27 @@ export class ElDmPopover extends BaseElement {
     const assigned = triggerSlot.assignedElements();
     return assigned[0] || null;
   }
+
+  private _getTriggerElement(): Element | null {
+    const assigned = this._getAssignedTriggerElement();
+    if (!assigned) return null;
+
+    if (assigned.matches(this._focusableSelector)) {
+      return assigned;
+    }
+
+    return assigned.querySelector(this._focusableSelector) ?? assigned;
+  }
+
+  private readonly _focusableSelector = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[contenteditable]:not([contenteditable="false"])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
 
   private _handleTriggerClick = (): void => {
     this.toggle();
@@ -333,6 +355,7 @@ export class ElDmPopover extends BaseElement {
   };
 
   private _handleTriggerFocus = (): void => {
+    if (this._restoringFocus) return;
     this.show();
   };
 
@@ -373,7 +396,13 @@ export class ElDmPopover extends BaseElement {
       this.hide();
       // Return focus to trigger element
       const triggerEl = this._getTriggerElement() as HTMLElement | null;
-      triggerEl?.focus?.();
+      if (triggerEl?.focus) {
+        this._restoringFocus = true;
+        triggerEl.focus();
+        queueMicrotask(() => {
+          this._restoringFocus = false;
+        });
+      }
     }
   }
 

--- a/packages/docs/src/content/docs/components/breadcrumbs.mdx
+++ b/packages/docs/src/content/docs/components/breadcrumbs.mdx
@@ -116,7 +116,18 @@ breadcrumbs.addEventListener('navigate', (e) => {
 
 | Slot | Description |
 |------|-------------|
+| `item` | Server-rendered breadcrumb item; repeated items retain their native links and attributes |
 | `separator` | Custom separator element between items |
+
+The final declarative `item` receives `aria-current="page"` automatically:
+
+```html
+<el-dm-breadcrumbs>
+  <span slot="item"><a href="/">Home</a></span>
+  <span slot="item"><a href="/components">Components</a></span>
+  <span slot="item">Breadcrumbs</span>
+</el-dm-breadcrumbs>
+```
 
 ## CSS Parts
 

--- a/packages/docs/src/content/docs/components/markdown.mdx
+++ b/packages/docs/src/content/docs/components/markdown.mdx
@@ -199,13 +199,14 @@ md.addEventListener('dm-rendered', (event) => {
 
 ## Security
 
-By default, the component sanitizes HTML to prevent XSS attacks. You can disable this for trusted content:
+By default, the component sanitizes HTML to prevent XSS attacks. Trusted callers can disable
+sanitization with the JavaScript property:
 
-````html
-<el-dm-markdown sanitize="false">
-  <div class="custom-html">Custom HTML allowed</div>
-</el-dm-markdown>
-````
+```javascript
+const markdown = document.querySelector('el-dm-markdown');
+markdown.sanitize = false;
+markdown.content = '<div class="custom-html">Trusted HTML</div>';
+```
 
 ⚠️ **Warning**: Only disable sanitization for trusted content sources.
 

--- a/packages/docs/src/content/docs/components/pagination.mdx
+++ b/packages/docs/src/content/docs/components/pagination.mdx
@@ -99,6 +99,27 @@ pagination.addEventListener('change', (e) => {
 });
 ```
 
+## Server-rendered navigation
+
+Use the declarative slots when navigation is owned by the server or router. Supplied links retain
+their `href` and framework-specific attributes, and the component does not intercept navigation.
+
+```html
+<el-dm-pagination>
+  <a slot="prev" href="/posts?page=1">Previous</a>
+  <a slot="page" href="/posts?page=1">1</a>
+  <a slot="page" href="/posts?page=2" aria-current="page">2</a>
+  <span slot="page" aria-hidden="true">…</span>
+  <a slot="next" href="/posts?page=3">Next</a>
+</el-dm-pagination>
+```
+
+| Slot | Description |
+|------|-------------|
+| `prev` / `previous` | Previous-page control |
+| `page` | Numbered page or ellipsis, repeatable in source order |
+| `next` | Next-page control |
+
 ## CSS Parts
 
 | Part | Description |


### PR DESCRIPTION
## Summary
- select the correct CodeMirror theme extension and preserve native submitter semantics
- add declarative server-rendered breadcrumb and pagination navigation
- sanitize Markdown by default and restore popover focus through wrapper triggers
- document the public APIs and add patch changesets for affected packages

## Issues
Fixes #65
Fixes #66
Fixes #67
Fixes #68
Fixes #69
Fixes #70

#71 was traced to the OXC 9.9.2 traversal stack overflow, resolved upstream in `duskmoon-dev/phoenix-duskmoon-ui#113` and released in v9.9.3; the issue was closed with the upgrade guidance.

## Verification
- 171 targeted tests pass across affected packages and the aggregate register bundle
- affected package typechecks and builds pass
- repository-wide lint and format checks pass
- documentation build passes

## Existing full-suite failures
`bun test` reports three unrelated order-dependent failures in tooltip registration and bottom-sheet open-state assertions. The clean `main` checkout reproduces those and four additional unrelated markdown-input/Mermaid failures; all affected package suites pass.